### PR TITLE
Fix HTML parsing of S-kaupat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.2
+
+- S-kaupat had changed a bit their order summary page -> fixed the HTML parsing of S-kaupat.
+    - Especially product price, quantity and name had changed.
+    - In the current S-kaupat HTML file the packaging material payment and the home delivery don't have quantity divs anymore.
+
 ## 0.1.1
 
 - Fix two pub publish warnings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - S-kaupat had changed a bit their order summary page -> fixed the HTML parsing of S-kaupat.
     - Especially product price, quantity and name had changed.
     - In the current S-kaupat HTML file the packaging material payment and the home delivery don't have quantity divs anymore.
+- Update API docs.
+- Fix S-kaupat example HTML file to fix tests.
 
 ## 0.1.1
 

--- a/doc/api/__404error.html
+++ b/doc/api/__404error.html
@@ -83,7 +83,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/index.html
+++ b/doc/api/index.html
@@ -43,7 +43,10 @@
   <div id="dartdoc-main-content" class="main-content">
       
 <section class="desc markdown">
-  <p><a href="https://github.com/areee/kassakuitti/actions/workflows/dart.yml"><img src="https://github.com/areee/kassakuitti/actions/workflows/dart.yml/badge.svg" alt="Dart CI"></a></p>
+  <p><a href="https://github.com/areee/kassakuitti/actions/workflows/dart.yml"><img src="https://github.com/areee/kassakuitti/actions/workflows/dart.yml/badge.svg" alt="Dart CI"></a>
+<a href="https://codecov.io/github/areee/kassakuitti"><img src="https://codecov.io/github/areee/kassakuitti/branch/main/graph/badge.svg?token=3URJPD5HD1" alt="codecov"></a>
+<a href="https://pub.dev/packages/kassakuitti"><img src="https://img.shields.io/pub/v/kassakuitti.svg" alt="pub package"></a>
+<a href="https://github.com/areee/kassakuitti/blob/main/LICENSE"><img src="https://img.shields.io/github/license/areee/kassakuitti" alt="license"></a></p>
 <p>A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).</p>
 <p>Currently this package works best with a command-line interface (CLI). This means that it should work only with Windows, macOS and Linux.</p>
 <h2 id="features">Features</h2>
@@ -98,6 +101,7 @@ var exportedFilePaths =
 <h2 id="additional-information">Additional information</h2>
 <p>This kassakuitti project set started from <a href="https://github.com/areee/dart_kassakuitti_cli">dart_kassakuitti_cli</a> project in October 2021.</p>
 <p>All contributions are welcome. If you would like to contribute, please give an <a href="https://github.com/areee/kassakuitti/issues/new">issue</a> to discuss about the problem.</p>
+<p>There are <a href="https://github.com/areee/kassakuitti/wiki">wiki pages</a> for this project. Please update them if you find some useful tricks for using Dart. Currently, there's only instructions for generating locally a coverage report.</p>
 <p>This project is authored by <a href="https://www.linkedin.com/in/arttuylh">Arttu Ylhävuori</a>.</p>
 </section>
 
@@ -147,7 +151,7 @@ handle a cash receipt coming from S-kaupat or K-ruoka
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct-class.html
+++ b/doc/api/kassakuitti/EANProduct-class.html
@@ -356,7 +356,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/EANProduct.html
+++ b/doc/api/kassakuitti/EANProduct/EANProduct.html
@@ -139,7 +139,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/isHomeDelivery.html
+++ b/doc/api/kassakuitti/EANProduct/isHomeDelivery.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/isPackagingMaterial.html
+++ b/doc/api/kassakuitti/EANProduct/isPackagingMaterial.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/moreDetails.html
+++ b/doc/api/kassakuitti/EANProduct/moreDetails.html
@@ -129,7 +129,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/toString.html
+++ b/doc/api/kassakuitti/EANProduct/toString.html
@@ -144,7 +144,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti-class.html
+++ b/doc/api/kassakuitti/Kassakuitti-class.html
@@ -320,7 +320,7 @@ Returns the path(s) of the exported file(s).
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/Kassakuitti.html
+++ b/doc/api/kassakuitti/Kassakuitti/Kassakuitti.html
@@ -136,7 +136,7 @@ Default values are:</p>
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/export.html
+++ b/doc/api/kassakuitti/Kassakuitti/export.html
@@ -170,7 +170,7 @@ Returns the path(s) of the exported file(s).</p>
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/htmlFilePath.html
+++ b/doc/api/kassakuitti/Kassakuitti/htmlFilePath.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/readEANProducts.html
+++ b/doc/api/kassakuitti/Kassakuitti/readEANProducts.html
@@ -133,7 +133,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/readReceiptProducts.html
+++ b/doc/api/kassakuitti/Kassakuitti/readReceiptProducts.html
@@ -136,7 +136,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/selectedFileFormat.html
+++ b/doc/api/kassakuitti/Kassakuitti/selectedFileFormat.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/selectedShop.html
+++ b/doc/api/kassakuitti/Kassakuitti/selectedShop.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/textFilePath.html
+++ b/doc/api/kassakuitti/Kassakuitti/textFilePath.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/toString.html
+++ b/doc/api/kassakuitti/Kassakuitti/toString.html
@@ -138,7 +138,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product-class.html
+++ b/doc/api/kassakuitti/Product-class.html
@@ -317,7 +317,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/Product.html
+++ b/doc/api/kassakuitti/Product/Product.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/eanCode.html
+++ b/doc/api/kassakuitti/Product/eanCode.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/isFruitOrVegetable.html
+++ b/doc/api/kassakuitti/Product/isFruitOrVegetable.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/name.html
+++ b/doc/api/kassakuitti/Product/name.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/pricePerUnit.html
+++ b/doc/api/kassakuitti/Product/pricePerUnit.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/quantity.html
+++ b/doc/api/kassakuitti/Product/quantity.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/totalPrice.html
+++ b/doc/api/kassakuitti/Product/totalPrice.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct-class.html
+++ b/doc/api/kassakuitti/ReceiptProduct-class.html
@@ -332,7 +332,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/ReceiptProduct.html
+++ b/doc/api/kassakuitti/ReceiptProduct/ReceiptProduct.html
@@ -137,7 +137,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/isDiscountCounted.html
+++ b/doc/api/kassakuitti/ReceiptProduct/isDiscountCounted.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/toString.html
+++ b/doc/api/kassakuitti/ReceiptProduct/toString.html
@@ -142,7 +142,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat.html
+++ b/doc/api/kassakuitti/SelectedFileFormat.html
@@ -341,7 +341,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/SelectedFileFormat.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/SelectedFileFormat.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/fileFormatName.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/fileFormatName.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/values-constant.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/values-constant.html
@@ -121,7 +121,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop.html
+++ b/doc/api/kassakuitti/SelectedShop.html
@@ -341,7 +341,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/SelectedShop.html
+++ b/doc/api/kassakuitti/SelectedShop/SelectedShop.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/shopName.html
+++ b/doc/api/kassakuitti/SelectedShop/shopName.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/values-constant.html
+++ b/doc/api/kassakuitti/SelectedShop/values-constant.html
@@ -121,7 +121,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/doc/api/kassakuitti/kassakuitti-library.html
+++ b/doc/api/kassakuitti/kassakuitti-library.html
@@ -175,7 +175,7 @@ handle a cash receipt coming from S-kaupat or K-ruoka
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.0
+      0.1.2
   </span>
 
   

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -23,97 +23,50 @@
                             <div>
                                 <div></div>
                                 <div data-product-id="6414894502399">
+                                    <div></div>
                                     <div>
+                                        <div>Kotimaista ruusukaali 300 g Suomi</div>
                                         <div>
-                                            <div></div>
-                                            <div>
-                                                <div><span>Kotimaista ruusukaali 300 g Suomi</span></div>
-                                                <div>
-                                                    <div></div>
-                                                    <div>
-                                                        <div><span>2</span>
-                                                            &nbsp;<span>KPL</span>
-                                                        </div>
-                                                        <div>5,96 €</div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <div>5,96 €</div>
                                         </div>
                                     </div>
+                                    <div><span><span>2</span><span>kpl</span></span></div>
                                 </div>
                                 <div data-product-id="6414894501231">
+                                    <div></div>
                                     <div>
+                                        <div>Kotimaista 1 kg suomalainen porkkana</div>
                                         <div>
-                                            <div></div>
-                                            <div>
-                                                <div><span>Kotimaista 1 kg suomalainen porkkana</span></div>
-                                                <div>
-                                                    <div></div>
-                                                    <div>
-                                                        <div><span>1</span>
-                                                            &nbsp;<span>KPL</span>
-                                                        </div>
-                                                        <div>1,35 €</div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <div>1,35 €</div>
                                         </div>
                                     </div>
+                                    <div><span><span>1</span><span>kpl</span></span></div>
                                 </div>
                                 <div data-product-id="2000604700007">
+                                    <div></div>
                                     <div>
+                                        <div>Kurkku Suomi</div>
                                         <div>
-                                            <div></div>
-                                            <div>
-                                                <div><span>Kurkku Suomi</span></div>
-                                                <div>
-                                                    <div></div>
-                                                    <div>
-                                                        <div><span>3</span>
-                                                            &nbsp;<span>KPL</span>
-                                                        </div>
-                                                        <div>4,83 €</div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <div>4,83 €</div>
                                         </div>
                                     </div>
+                                    <div><span><span>3</span><span>kpl</span></span></div>
                                 </div>
                                 <div data-product-id="0200060667032">
+                                    <div></div>
                                     <div>
+                                        <div>Pakkausmateriaalimaksu</div>
                                         <div>
-                                            <div></div>
-                                            <div>
-                                                <div><span>Pakkausmateriaalimaksu</span></div>
-                                                <div>
-                                                    <div></div>
-                                                    <div>
-                                                        <div><span>1</span>
-                                                            &nbsp;<span>KPL</span>
-                                                        </div>
-                                                        <div>0,60 €</div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <div>0,60 €</div>
                                         </div>
                                     </div>
                                 </div>
                                 <div data-product-id="0200096900752">
+                                    <div></div>
                                     <div>
+                                        <div>Kotiinkuljetus</div>
                                         <div>
-                                            <div></div>
-                                            <div>
-                                                <div><span>Kotiinkuljetus</span></div>
-                                                <div>
-                                                    <div></div>
-                                                    <div>
-                                                        <div><span>1</span>
-                                                            &nbsp;<span>KPL</span>
-                                                        </div>
-                                                        <div>10,90 €</div>
-                                                    </div>
-                                                </div>
-                                            </div>
+                                            <div>10,90 €</div>
                                         </div>
                                     </div>
                                 </div>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -23,18 +23,24 @@ void _html2EANProductsFromDocument(
   var childrenOfAllProductsDiv = allProductsDiv.children;
   for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {
     var product = childrenOfAllProductsDiv[i];
-    var productPrice = double.parse(product.children[0].children[0].children[1]
-        .children[1].children[1].children[1].text
+    var productPrice = double.parse(product
+        .children[1].children[1].children[0].text
         .trim()
         .removeAllEuros()
         .replaceAllCommasWithDots());
-    var quantity = double.parse(product.children[0].children[0].children[1]
-            .children[1].children[1].children[0].children[0].text)
-        .ceil();
 
+    /*
+      Try to get the second child of the product (quantity div).
+      If it doesn't exist (e.g. packaging material payment and home delivery don't have quantity div),
+      then set quantity to 1.
+    */
+    int quantity = 1;
+    if (product.children.length > 2) {
+      quantity =
+          double.parse(product.children[2].children[0].children[0].text).ceil();
+    }
     eanProducts.add(EANProduct(
-      name: product
-          .children[0].children[0].children[1].children[0].children[0].text
+      name: product.children[1].children[0].text
           .trim()
           .removeAllNewLines()
           .replaceAllWhitespacesWithSingleSpace(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- S-kaupat had changed a bit their order summary page -> fixed the HTML parsing of S-kaupat.
    - Especially product price, quantity and name had changed.
    - In the current S-kaupat HTML file the packaging material payment and the home delivery don't have quantity divs anymore.
- Update API docs.
- Fix S-kaupat example HTML file to fix tests.