### PR TITLE
Fix a price bug + some small changes to examples & tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.3
+
+- A bug: currently, S-kaupat HTML file has a price per unit as a price for a product, not a total price as earlier. Fix the parsing logic of S-kaupat HTML file.
+- Fix 'Reading receiptProducts work' test.
+- Small price fixes into cash receipt example & S-kaupat HTML example.
+
 # 0.1.2
 
 - S-kaupat had changed a bit their order summary page -> fixed the HTML parsing of S-kaupat.

--- a/example/cash_receipt_example.txt
+++ b/example/cash_receipt_example.txt
@@ -2,6 +2,7 @@
        2 KPL       2,98 €/KPL
  PORKKANAPUSSI                        1,35 
  KURKKU SUOMI                         4,50 
+       3 KPL       1,50 €/KPL
  PAKKAUSMATERIAALIT                   0,60 
  TOIMITUSMAKSU 10,90                 10,90 
                                  ----------

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -27,7 +27,7 @@
                                     <div>
                                         <div>Kotimaista ruusukaali 300 g Suomi</div>
                                         <div>
-                                            <div>5,96 €</div>
+                                            <div>2,98 €</div>
                                         </div>
                                     </div>
                                     <div><span><span>2</span><span>kpl</span></span></div>
@@ -47,7 +47,7 @@
                                     <div>
                                         <div>Kurkku Suomi</div>
                                         <div>
-                                            <div>4,83 €</div>
+                                            <div>1,61 €</div>
                                         </div>
                                     </div>
                                     <div><span><span>3</span><span>kpl</span></span></div>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -23,7 +23,7 @@ void _html2EANProductsFromDocument(
   var childrenOfAllProductsDiv = allProductsDiv.children;
   for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {
     var product = childrenOfAllProductsDiv[i];
-    var productPrice = double.parse(product
+    var pricePerUnit = double.parse(product
         .children[1].children[1].children[0].text
         .trim()
         .removeAllEuros()
@@ -44,12 +44,10 @@ void _html2EANProductsFromDocument(
           .trim()
           .removeAllNewLines()
           .replaceAllWhitespacesWithSingleSpace(),
-      totalPrice: productPrice,
+      totalPrice: (pricePerUnit * quantity).toPrecision(2),
       quantity: quantity,
       eanCode: product.attributes['data-product-id'] ?? '',
-      pricePerUnit: quantity == 1 || quantity == 0
-          ? null
-          : (productPrice / quantity).toPrecision(2),
+      pricePerUnit: quantity == 1 || quantity == 0 ? null : pricePerUnit,
     ));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.1.2
+version: 0.1.3
 repository: https://github.com/areee/kassakuitti
 
 environment:

--- a/test/kassakuitti_test.dart
+++ b/test/kassakuitti_test.dart
@@ -498,8 +498,8 @@ void main() {
       expect(receiptProducts[1].pricePerUnit, null);
       expect(receiptProducts[2].name, 'kurkku suomi');
       expect(receiptProducts[2].totalPrice, 4.5);
-      expect(receiptProducts[2].quantity, 1);
-      expect(receiptProducts[2].pricePerUnit, null);
+      expect(receiptProducts[2].quantity, 3);
+      expect(receiptProducts[2].pricePerUnit, 1.5);
       expect(receiptProducts[3].name, 'pakkausmateriaalit');
       expect(receiptProducts[3].totalPrice, 0.6);
       expect(receiptProducts[3].quantity, 1);


### PR DESCRIPTION
Resolves #9 

- A bug: currently, S-kaupat HTML file has a price per unit as a price for a product, not a total price as earlier. Fix the parsing logic of S-kaupat HTML file.
- Fix 'Reading receiptProducts work' test.
- Small price fixes into cash receipt example & S-kaupat HTML example.