### PR TITLE
Fix some usage problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.0
+
+- When a product has a counted discount, do not show a boolean value but a 'yes' string and a yellow background in the row of an Excel / XLSX file.
+- Fix a HTML file parsing into EAN products when a quantity field has a decimal instead of an integer (e.g. 0,6 instead of 1).
+- Fix a text file parsing into receipt products. Earlier was 8–35 whitespaces between a "normal" product name and total price, but e.g. 6 whitespaces didn't get splitted. Now all whitespaces beginning from 2 whitespaces are supported.
+- Enhance test coverage a bit.
+- Fix some changelog header levels.
+
 ## 0.1.3
 
 - A bug: currently, S-kaupat HTML file has a price per unit as a price for a product, not a total price as earlier. Fix the parsing logic of S-kaupat HTML file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.2.0
 
 - When a product has a counted discount, do not show a boolean value but a 'yes' string and a yellow background in the row of an Excel / XLSX file.
-- Fix a HTML file parsing into EAN products when a quantity field has a decimal instead of an integer (e.g. 0,6 instead of 1).
+- Fix an HTML file parsing into EAN products when a quantity field has a decimal instead of an integer (e.g. 0,6 instead of 1).
 - Fix a text file parsing into receipt products. Earlier was 8–35 whitespaces between a "normal" product name and total price, but e.g. 6 whitespaces didn't get splitted. Now all whitespaces beginning from 2 whitespaces are supported.
 - Enhance test coverage a bit.
 - Fix some changelog header levels.

--- a/lib/src/export_into_csv.dart
+++ b/lib/src/export_into_csv.dart
@@ -35,7 +35,7 @@ Future<String> exportReceiptProductsIntoCsv(
       product.eanCode,
     ];
     if (discountCounted) {
-      productDataList.add(product.isDiscountCounted);
+      productDataList.add(product.isDiscountCounted ? 'yes' : '');
     }
     csv.write('${productDataList.join(';')}\n');
   }

--- a/lib/src/export_into_excel.dart
+++ b/lib/src/export_into_excel.dart
@@ -38,7 +38,7 @@ Future<String> exportReceiptProductsIntoExcel(
       product.eanCode,
     ];
     if (discountCounted) {
-      productDataList.add(product.isDiscountCounted);
+      productDataList.add(product.isDiscountCounted ? 'yes' : '');
     }
     sheetObject?.insertRowIterables(
         productDataList, receiptProducts.indexOf(product) + 1);
@@ -47,6 +47,12 @@ Future<String> exportReceiptProductsIntoExcel(
     if (product.isFruitOrVegetable) {
       sheetObject?.updateSelectedRowStyle(receiptProducts.indexOf(product) + 1,
           CellStyle(backgroundColorHex: '#00FF00'));
+    }
+
+    // If the product is a discount, change the background color to yellow.
+    if (product.isDiscountCounted) {
+      sheetObject?.updateSelectedRowStyle(receiptProducts.indexOf(product) + 1,
+          CellStyle(backgroundColorHex: '#FFFF00'));
     }
   }
   // Save to the Excel (xlsx) file:

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -36,8 +36,9 @@ void _html2EANProductsFromDocument(
     */
     int quantity = 1;
     if (product.children.length > 2) {
-      quantity =
-          double.parse(product.children[2].children[0].children[0].text).ceil();
+      quantity = double.parse(product.children[2].children[0].children[0].text
+              .replaceAllCommasWithDots())
+          .ceil();
     }
     eanProducts.add(EANProduct(
       name: product.children[1].children[0].text

--- a/lib/src/strings_to_receipt_products.dart
+++ b/lib/src/strings_to_receipt_products.dart
@@ -66,12 +66,12 @@ void _handleRefundRow(RowHelper helper) {
 void _handleDiscountOrCampaignRow(
     String row, List<ReceiptProduct> receiptProducts) {
   /*
-    Split by 12-33 whitespaces.
+    Split by two or more whitespaces.
     An example of a discount row:
     S-Etu alennus                        0,89-
   */
-  var splittedItems = row.split(RegExp(r'\s{12,33}'));
-  var discountPrice = double.parse(splittedItems[1]
+  var items = row.splitByTwoOrMoreWhitespaces();
+  var discountPrice = double.parse(items[1]
       .replaceAll(RegExp(r'\-'), '') // Remove minus sign.
       .replaceAllCommasWithDots());
 
@@ -91,11 +91,11 @@ void _handleDiscountOrCampaignRow(
 void _handleQuantityAndPricePerUnitRow(
     String row, List<ReceiptProduct> receiptProducts) {
   /*
-    Split by 6-7 whitespaces between quantity and price per unit.
+    Split by two or more whitespaces between quantity and price per unit.
     An example:
     2 kpl       2,98 €/kpl
   */
-  var items = row.split(RegExp(r'\s{6,7}'));
+  var items = row.splitByTwoOrMoreWhitespaces();
   var quantity = items[0].substring(0, 2).trim().replaceAllCommasWithDots();
 
   var lastProduct = receiptProducts.last;
@@ -107,7 +107,7 @@ void _handleQuantityAndPricePerUnitRow(
 /// Handle a "normal" row. An example:
 /// PERUNA-SIPULISEKOITUS                0,85
 void _handleNormalRow(String row, List<ReceiptProduct> receiptProducts) {
-  var items = row.split(RegExp(r'\s{8,35}'));
+  var items = row.splitByTwoOrMoreWhitespaces();
   var product = ReceiptProduct(
       name: items[0],
       totalPrice: double.parse(items[1].trim().replaceAllCommasWithDots()));

--- a/lib/src/utils/extensions/string_extension.dart
+++ b/lib/src/utils/extensions/string_extension.dart
@@ -24,4 +24,9 @@ extension StringExtension on String {
   String removeAllKplsAndKgs() {
     return replaceAll('kpl', '').replaceAll('kg', '');
   }
+
+  /// Split the string by two or more whitespaces.
+  List<String> splitByTwoOrMoreWhitespaces() {
+    return split(RegExp(r'\s{2,}'));
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.1.3
+version: 0.2.0
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- When a product has a counted discount, do not show a boolean value but a 'yes' string and a yellow background in the row of an Excel / XLSX file.
- Fix an HTML file parsing into EAN products when a quantity field has a decimal instead of an integer (e.g. 0,6 instead of 1).
- Fix a text file parsing into receipt products. Earlier was 8–35 whitespaces between a "normal" product name and total price, but e.g. 6 whitespaces didn't get splitted. Now all whitespaces beginning from 2 whitespaces are supported.