### PR TITLE
Fix receipt product splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1
+
+- Fix a case where a receipt product row had mistakenly two whitespaces between the name parts. An example: "Juusto  10%".
+    - Now it allows even three whitespaces between them. Starting with four whitespaces it can be assumed that it's a separator between the name and the total price.
+
 ## 0.2.0
 
 - When a product has a counted discount, do not show a boolean value but a 'yes' string and a yellow background in the row of an Excel / XLSX file.

--- a/doc/api/__404error.html
+++ b/doc/api/__404error.html
@@ -83,7 +83,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/index.html
+++ b/doc/api/index.html
@@ -151,7 +151,7 @@ handle a cash receipt coming from S-kaupat or K-ruoka
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct-class.html
+++ b/doc/api/kassakuitti/EANProduct-class.html
@@ -356,7 +356,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/EANProduct.html
+++ b/doc/api/kassakuitti/EANProduct/EANProduct.html
@@ -139,7 +139,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/isHomeDelivery.html
+++ b/doc/api/kassakuitti/EANProduct/isHomeDelivery.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/isPackagingMaterial.html
+++ b/doc/api/kassakuitti/EANProduct/isPackagingMaterial.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/moreDetails.html
+++ b/doc/api/kassakuitti/EANProduct/moreDetails.html
@@ -129,7 +129,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/toString.html
+++ b/doc/api/kassakuitti/EANProduct/toString.html
@@ -144,7 +144,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti-class.html
+++ b/doc/api/kassakuitti/Kassakuitti-class.html
@@ -320,7 +320,7 @@ Returns the path(s) of the exported file(s).
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/Kassakuitti.html
+++ b/doc/api/kassakuitti/Kassakuitti/Kassakuitti.html
@@ -136,7 +136,7 @@ Default values are:</p>
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/export.html
+++ b/doc/api/kassakuitti/Kassakuitti/export.html
@@ -170,7 +170,7 @@ Returns the path(s) of the exported file(s).</p>
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/htmlFilePath.html
+++ b/doc/api/kassakuitti/Kassakuitti/htmlFilePath.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/readEANProducts.html
+++ b/doc/api/kassakuitti/Kassakuitti/readEANProducts.html
@@ -133,7 +133,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/readReceiptProducts.html
+++ b/doc/api/kassakuitti/Kassakuitti/readReceiptProducts.html
@@ -136,7 +136,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/selectedFileFormat.html
+++ b/doc/api/kassakuitti/Kassakuitti/selectedFileFormat.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/selectedShop.html
+++ b/doc/api/kassakuitti/Kassakuitti/selectedShop.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/textFilePath.html
+++ b/doc/api/kassakuitti/Kassakuitti/textFilePath.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/toString.html
+++ b/doc/api/kassakuitti/Kassakuitti/toString.html
@@ -138,7 +138,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product-class.html
+++ b/doc/api/kassakuitti/Product-class.html
@@ -317,7 +317,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/Product.html
+++ b/doc/api/kassakuitti/Product/Product.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/eanCode.html
+++ b/doc/api/kassakuitti/Product/eanCode.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/isFruitOrVegetable.html
+++ b/doc/api/kassakuitti/Product/isFruitOrVegetable.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/name.html
+++ b/doc/api/kassakuitti/Product/name.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/pricePerUnit.html
+++ b/doc/api/kassakuitti/Product/pricePerUnit.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/quantity.html
+++ b/doc/api/kassakuitti/Product/quantity.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/Product/totalPrice.html
+++ b/doc/api/kassakuitti/Product/totalPrice.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct-class.html
+++ b/doc/api/kassakuitti/ReceiptProduct-class.html
@@ -332,7 +332,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/ReceiptProduct.html
+++ b/doc/api/kassakuitti/ReceiptProduct/ReceiptProduct.html
@@ -137,7 +137,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/isDiscountCounted.html
+++ b/doc/api/kassakuitti/ReceiptProduct/isDiscountCounted.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/toString.html
+++ b/doc/api/kassakuitti/ReceiptProduct/toString.html
@@ -142,7 +142,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat.html
+++ b/doc/api/kassakuitti/SelectedFileFormat.html
@@ -341,7 +341,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/SelectedFileFormat.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/SelectedFileFormat.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/fileFormatName.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/fileFormatName.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/values-constant.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/values-constant.html
@@ -121,7 +121,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop.html
+++ b/doc/api/kassakuitti/SelectedShop.html
@@ -341,7 +341,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/SelectedShop.html
+++ b/doc/api/kassakuitti/SelectedShop/SelectedShop.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/shopName.html
+++ b/doc/api/kassakuitti/SelectedShop/shopName.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/values-constant.html
+++ b/doc/api/kassakuitti/SelectedShop/values-constant.html
@@ -121,7 +121,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/doc/api/kassakuitti/kassakuitti-library.html
+++ b/doc/api/kassakuitti/kassakuitti-library.html
@@ -175,7 +175,7 @@ handle a cash receipt coming from S-kaupat or K-ruoka
 <footer>
   <span class="no-break">
     kassakuitti
-      0.1.2
+      0.2.1
   </span>
 
   

--- a/lib/src/strings_to_receipt_products.dart
+++ b/lib/src/strings_to_receipt_products.dart
@@ -70,7 +70,7 @@ void _handleDiscountOrCampaignRow(
     An example of a discount row:
     S-Etu alennus                        0,89-
   */
-  var items = row.splitByTwoOrMoreWhitespaces();
+  var items = row.splitByFourOrMoreWhitespaces();
   var discountPrice = double.parse(items[1]
       .replaceAll(RegExp(r'\-'), '') // Remove minus sign.
       .replaceAllCommasWithDots());
@@ -95,7 +95,7 @@ void _handleQuantityAndPricePerUnitRow(
     An example:
     2 kpl       2,98 €/kpl
   */
-  var items = row.splitByTwoOrMoreWhitespaces();
+  var items = row.splitByFourOrMoreWhitespaces();
   var quantity = items[0].substring(0, 2).trim().replaceAllCommasWithDots();
 
   var lastProduct = receiptProducts.last;
@@ -107,7 +107,7 @@ void _handleQuantityAndPricePerUnitRow(
 /// Handle a "normal" row. An example:
 /// PERUNA-SIPULISEKOITUS                0,85
 void _handleNormalRow(String row, List<ReceiptProduct> receiptProducts) {
-  var items = row.splitByTwoOrMoreWhitespaces();
+  var items = row.splitByFourOrMoreWhitespaces();
   var product = ReceiptProduct(
       name: items[0],
       totalPrice: double.parse(items[1].trim().replaceAllCommasWithDots()));

--- a/lib/src/utils/extensions/string_extension.dart
+++ b/lib/src/utils/extensions/string_extension.dart
@@ -25,8 +25,8 @@ extension StringExtension on String {
     return replaceAll('kpl', '').replaceAll('kg', '');
   }
 
-  /// Split the string by two or more whitespaces.
-  List<String> splitByTwoOrMoreWhitespaces() {
-    return split(RegExp(r'\s{2,}'));
+  /// Split the string by four or more whitespaces.
+  List<String> splitByFourOrMoreWhitespaces() {
+    return split(RegExp(r'\s{4,}'));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- Fix a case where a receipt product row had mistakenly two whitespaces between the name parts. An example: "Juusto  10%".
    - Now it allows even three whitespaces between them. Starting with four whitespaces it can be assumed that it's a separator between the name and the total price.