### PR TITLE
Fix the price field (unit price -> total price)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.2
+
+- S-kaupat had changed their price field in the EAN products. Now it's again a total price, not a unit price as it was for some weeks (compare to version 0.1.3 changes).
+- Fix S-kaupat example file.
+- Update API docs (nothing but the version number has changed).
+
 ## 0.2.1
 
 - Fix a case where a receipt product row had mistakenly two whitespaces between the name parts. An example: "Juusto  10%".

--- a/doc/api/__404error.html
+++ b/doc/api/__404error.html
@@ -83,7 +83,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/index.html
+++ b/doc/api/index.html
@@ -151,7 +151,7 @@ handle a cash receipt coming from S-kaupat or K-ruoka
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct-class.html
+++ b/doc/api/kassakuitti/EANProduct-class.html
@@ -356,7 +356,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/EANProduct.html
+++ b/doc/api/kassakuitti/EANProduct/EANProduct.html
@@ -139,7 +139,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/isHomeDelivery.html
+++ b/doc/api/kassakuitti/EANProduct/isHomeDelivery.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/isPackagingMaterial.html
+++ b/doc/api/kassakuitti/EANProduct/isPackagingMaterial.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/moreDetails.html
+++ b/doc/api/kassakuitti/EANProduct/moreDetails.html
@@ -129,7 +129,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/EANProduct/toString.html
+++ b/doc/api/kassakuitti/EANProduct/toString.html
@@ -144,7 +144,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti-class.html
+++ b/doc/api/kassakuitti/Kassakuitti-class.html
@@ -320,7 +320,7 @@ Returns the path(s) of the exported file(s).
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/Kassakuitti.html
+++ b/doc/api/kassakuitti/Kassakuitti/Kassakuitti.html
@@ -136,7 +136,7 @@ Default values are:</p>
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/export.html
+++ b/doc/api/kassakuitti/Kassakuitti/export.html
@@ -170,7 +170,7 @@ Returns the path(s) of the exported file(s).</p>
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/htmlFilePath.html
+++ b/doc/api/kassakuitti/Kassakuitti/htmlFilePath.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/readEANProducts.html
+++ b/doc/api/kassakuitti/Kassakuitti/readEANProducts.html
@@ -133,7 +133,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/readReceiptProducts.html
+++ b/doc/api/kassakuitti/Kassakuitti/readReceiptProducts.html
@@ -136,7 +136,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/selectedFileFormat.html
+++ b/doc/api/kassakuitti/Kassakuitti/selectedFileFormat.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/selectedShop.html
+++ b/doc/api/kassakuitti/Kassakuitti/selectedShop.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/textFilePath.html
+++ b/doc/api/kassakuitti/Kassakuitti/textFilePath.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Kassakuitti/toString.html
+++ b/doc/api/kassakuitti/Kassakuitti/toString.html
@@ -138,7 +138,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product-class.html
+++ b/doc/api/kassakuitti/Product-class.html
@@ -317,7 +317,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/Product.html
+++ b/doc/api/kassakuitti/Product/Product.html
@@ -134,7 +134,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/eanCode.html
+++ b/doc/api/kassakuitti/Product/eanCode.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/isFruitOrVegetable.html
+++ b/doc/api/kassakuitti/Product/isFruitOrVegetable.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/name.html
+++ b/doc/api/kassakuitti/Product/name.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/pricePerUnit.html
+++ b/doc/api/kassakuitti/Product/pricePerUnit.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/quantity.html
+++ b/doc/api/kassakuitti/Product/quantity.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/Product/totalPrice.html
+++ b/doc/api/kassakuitti/Product/totalPrice.html
@@ -126,7 +126,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct-class.html
+++ b/doc/api/kassakuitti/ReceiptProduct-class.html
@@ -332,7 +332,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/ReceiptProduct.html
+++ b/doc/api/kassakuitti/ReceiptProduct/ReceiptProduct.html
@@ -137,7 +137,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/isDiscountCounted.html
+++ b/doc/api/kassakuitti/ReceiptProduct/isDiscountCounted.html
@@ -127,7 +127,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/ReceiptProduct/toString.html
+++ b/doc/api/kassakuitti/ReceiptProduct/toString.html
@@ -142,7 +142,7 @@ String toString() {
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat.html
+++ b/doc/api/kassakuitti/SelectedFileFormat.html
@@ -341,7 +341,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/SelectedFileFormat.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/SelectedFileFormat.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/fileFormatName.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/fileFormatName.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedFileFormat/values-constant.html
+++ b/doc/api/kassakuitti/SelectedFileFormat/values-constant.html
@@ -121,7 +121,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop.html
+++ b/doc/api/kassakuitti/SelectedShop.html
@@ -341,7 +341,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/SelectedShop.html
+++ b/doc/api/kassakuitti/SelectedShop/SelectedShop.html
@@ -125,7 +125,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/shopName.html
+++ b/doc/api/kassakuitti/SelectedShop/shopName.html
@@ -132,7 +132,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/SelectedShop/values-constant.html
+++ b/doc/api/kassakuitti/SelectedShop/values-constant.html
@@ -121,7 +121,7 @@
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/doc/api/kassakuitti/kassakuitti-library.html
+++ b/doc/api/kassakuitti/kassakuitti-library.html
@@ -175,7 +175,7 @@ handle a cash receipt coming from S-kaupat or K-ruoka
 <footer>
   <span class="no-break">
     kassakuitti
-      0.2.1
+      0.2.2
   </span>
 
   

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -27,7 +27,7 @@
                                     <div>
                                         <div>Kotimaista ruusukaali 300 g Suomi</div>
                                         <div>
-                                            <div>2,98 €</div>
+                                            <div>5,96 €</div>
                                         </div>
                                     </div>
                                     <div><span><span>2</span><span>kpl</span></span></div>
@@ -47,7 +47,7 @@
                                     <div>
                                         <div>Kurkku Suomi</div>
                                         <div>
-                                            <div>1,61 €</div>
+                                            <div>4,83 €</div>
                                         </div>
                                     </div>
                                     <div><span><span>3</span><span>kpl</span></span></div>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -23,7 +23,7 @@ void _html2EANProductsFromDocument(
   var childrenOfAllProductsDiv = allProductsDiv.children;
   for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {
     var product = childrenOfAllProductsDiv[i];
-    var pricePerUnit = double.parse(product
+    var totalPrice = double.parse(product
         .children[1].children[1].children[0].text
         .trim()
         .removeAllEuros()
@@ -45,10 +45,12 @@ void _html2EANProductsFromDocument(
           .trim()
           .removeAllNewLines()
           .replaceAllWhitespacesWithSingleSpace(),
-      totalPrice: (pricePerUnit * quantity).toPrecision(2),
+      totalPrice: totalPrice,
       quantity: quantity,
       eanCode: product.attributes['data-product-id'] ?? '',
-      pricePerUnit: quantity == 1 || quantity == 0 ? null : pricePerUnit,
+      pricePerUnit: quantity == 1 || quantity == 0
+          ? null
+          : (totalPrice / quantity).toPrecision(2),
     ));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- S-kaupat had changed their price field in the EAN products. Now it's again a total price, not a unit price as it was for some weeks (compare to version 0.1.3 changes).
- Fix S-kaupat example file.
- Update API docs (nothing but the version number has changed).