### PR TITLE
Fix "tasaerä" row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-dev.2
+
+- Update Dart SDK & dependencies.
+- Fix a bug: if there's a row containing a word "tasaerä" ("equal instalment"), skip it.
+
 ## 1.0.0-dev.1
 
 - Update dependencies.
@@ -10,8 +15,8 @@
 
 ## 0.2.1
 
-- Fix a case where a receipt product row had mistakenly two whitespaces between the name parts. An example: "Juusto  10%".
-    - Now it allows even three whitespaces between them. Starting with four whitespaces it can be assumed that it's a separator between the name and the total price.
+- Fix a case where a receipt product row had mistakenly two whitespaces between the name parts. An example: "Juusto 10%".
+  - Now it allows even three whitespaces between them. Starting with four whitespaces it can be assumed that it's a separator between the name and the total price.
 
 ## 0.2.0
 
@@ -30,21 +35,21 @@
 ## 0.1.2
 
 - S-kaupat had changed a bit their order summary page -> fixed the HTML parsing of S-kaupat.
-    - Especially product price, quantity and name had changed.
-    - In the current S-kaupat HTML file the packaging material payment and the home delivery don't have quantity divs anymore.
+  - Especially product price, quantity and name had changed.
+  - In the current S-kaupat HTML file the packaging material payment and the home delivery don't have quantity divs anymore.
 - Update API docs.
 - Fix S-kaupat example HTML file to fix tests.
 
 ## 0.1.1
 
 - Fix two pub publish warnings:
-    - rename LICENSE.md to LICENSE and
-    - change excel dependency to flutter_excel (a prerelease versus a stable release).
+  - rename LICENSE.md to LICENSE and
+  - change excel dependency to flutter_excel (a prerelease versus a stable release).
 
 ## 0.1.0
 
 - Add a minimum viable product (MVP). It includes:
-    - a Kassakuitti instance,
-    - read a text file containing receipt products (only for S-kaupat),
-    - read an HTML file containing EAN products (for both S-kaupat and K-ruoka) and
-    - export both product types into CSV or Excel (XLSX) file based on the choice.
+  - a Kassakuitti instance,
+  - read a text file containing receipt products (only for S-kaupat),
+  - read an HTML file containing EAN products (for both S-kaupat and K-ruoka) and
+  - export both product types into CSV or Excel (XLSX) file based on the choice.

--- a/lib/src/strings_to_receipt_products.dart
+++ b/lib/src/strings_to_receipt_products.dart
@@ -30,18 +30,25 @@ void _strings2ReceiptProductsFromList(
     // Replace non-breaking space with a normal space
     row = row.replaceAll(RegExp(r'\u00a0'), ' ');
 
-    // Do not handle sum rows (after a row of strokes):
     if (row.contains('----------')) {
+      // A sum row: stop reading
       break;
     } else if (row.contains('palautus')) {
+      // A refund row
       helper.previousRow = PreviousRow.refund;
     } else if (helper.previousRow == PreviousRow.refund) {
       _handleRefundRow(helper);
+    } else if (row.contains('tasaerä')) {
+      // An "equal instalment" row: skip it
+      continue;
     } else if (row.contains('alennus') || row.contains('kampanja')) {
+      // A discount or campaign row
       _handleDiscountOrCampaignRow(row, receiptProducts);
     } else if (row.startsWith(RegExp(r'^\d+\s{1}kpl'))) {
+      // A quantity and price per unit row
       _handleQuantityAndPricePerUnitRow(row, receiptProducts);
     } else {
+      // A "normal" row
       _handleNormalRow(row, receiptProducts);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 1.0.0-dev.1
+version: 1.0.0-dev.2
 repository: https://github.com/areee/kassakuitti
 
 environment:
-  sdk: '>=2.18.4 <3.0.0'
+  sdk: ">=2.19.1 <3.0.0"
 
 dependencies:
   flutter_excel: ^1.0.1
   html: ^0.15.1
   intl: ^0.18.0
-  mime: ^1.0.3
+  mime: ^1.0.4
   path: ^1.8.3
   tuple: ^2.0.1
 
 dev_dependencies:
   lints: ^2.0.1
-  test: ^1.22.1
+  test: ^1.22.2


### PR DESCRIPTION
- Update Dart SDK & dependencies.
- Fix a bug: if there's a row containing a word "tasaerä" ("equal instalment"), skip it.