### PR TITLE
Fix parsing an S-kaupat HTML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+- Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was added there (again).
+- Update one dependency & update Dart SDK version to the latest stable Flutter version (Dart 2.19.4).
+
 ## 0.3.0
 
 - Merge with changes in the prerelease version (1.0.0-dev.2).

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -11,6 +11,7 @@
         <div></div>
         <div>
             <div></div>
+            <div></div>
             <div>
                 <div>
                     <div>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -18,7 +18,7 @@ Future<List<EANProduct>> html2EANProducts(String? filePath) async {
 /// Read EAN products from a [Document].
 void _html2EANProductsFromDocument(
     Document htmlDocument, List<EANProduct> eanProducts) {
-  var allProductsDiv = htmlDocument.body!.children[1].children[1].children[1]
+  var allProductsDiv = htmlDocument.body!.children[1].children[1].children[2]
       .children[0].children[0].children[1].children[5];
   var childrenOfAllProductsDiv = allProductsDiv.children;
   for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/areee/kassakuitti
 
 environment:
-  sdk: '>=2.19.2 <3.0.0'
+  sdk: '>=2.19.4 <3.0.0'
 
 dependencies:
   flutter_excel: ^1.0.1
-  html: ^0.15.1
+  html: ^0.15.2
   intl: ^0.18.0
   mime: ^1.0.4
   path: ^1.8.3


### PR DESCRIPTION
- Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was added there (again).
- Update one dependency & update Dart SDK version to the latest stable Flutter version (Dart 2.19.4).