### PR TITLE
Fix S-kaupat html file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.1
 
 - Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed & one extra div was added.
+- Update S-kaupat example HTML file (to fix broken tests).
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed & one extra div was added.
+
 ## 0.5.0
 
 - Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was added there (again).

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -1,84 +1,89 @@
 <!DOCTYPE html>
 <html>
-
-<head>
+  <head>
     <title>Otsikko</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <div></div>
     <div>
+      <div></div>
+      <div>
         <div></div>
         <div>
-            <div></div>
-            <div></div>
+          <div>
             <div>
+              <div></div>
+              <div>
                 <div>
-                    <div>
-                        <div></div>
+                  <div></div>
+                  <div></div>
+                  <div></div>
+                  <div></div>
+                  <div></div>
+                  <div>
+                    <div></div>
+                    <div data-product-id="6414894502399">
+                      <div></div>
+                      <div>
+                        <div>Kotimaista ruusukaali 300 g Suomi</div>
                         <div>
-                            <div></div>
-                            <div></div>
-                            <div></div>
-                            <div></div>
-                            <div></div>
-                            <div>
-                                <div></div>
-                                <div data-product-id="6414894502399">
-                                    <div></div>
-                                    <div>
-                                        <div>Kotimaista ruusukaali 300 g Suomi</div>
-                                        <div>
-                                            <div>5,96 €</div>
-                                        </div>
-                                    </div>
-                                    <div><span><span>2</span><span>kpl</span></span></div>
-                                </div>
-                                <div data-product-id="6414894501231">
-                                    <div></div>
-                                    <div>
-                                        <div>Kotimaista 1 kg suomalainen porkkana</div>
-                                        <div>
-                                            <div>1,35 €</div>
-                                        </div>
-                                    </div>
-                                    <div><span><span>1</span><span>kpl</span></span></div>
-                                </div>
-                                <div data-product-id="2000604700007">
-                                    <div></div>
-                                    <div>
-                                        <div>Kurkku Suomi</div>
-                                        <div>
-                                            <div>4,83 €</div>
-                                        </div>
-                                    </div>
-                                    <div><span><span>3</span><span>kpl</span></span></div>
-                                </div>
-                                <div data-product-id="0200060667032">
-                                    <div></div>
-                                    <div>
-                                        <div>Pakkausmateriaalimaksu</div>
-                                        <div>
-                                            <div>0,60 €</div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div data-product-id="0200096900752">
-                                    <div></div>
-                                    <div>
-                                        <div>Kotiinkuljetus</div>
-                                        <div>
-                                            <div>10,90 €</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                          <div>5,96 €</div>
                         </div>
+                      </div>
+                      <div>
+                        <span><span>2</span><span>kpl</span></span>
+                      </div>
                     </div>
+                    <div data-product-id="6414894501231">
+                      <div></div>
+                      <div>
+                        <div>Kotimaista 1 kg suomalainen porkkana</div>
+                        <div>
+                          <div>1,35 €</div>
+                        </div>
+                      </div>
+                      <div>
+                        <span><span>1</span><span>kpl</span></span>
+                      </div>
+                    </div>
+                    <div data-product-id="2000604700007">
+                      <div></div>
+                      <div>
+                        <div>Kurkku Suomi</div>
+                        <div>
+                          <div>4,83 €</div>
+                        </div>
+                      </div>
+                      <div>
+                        <span><span>3</span><span>kpl</span></span>
+                      </div>
+                    </div>
+                    <div data-product-id="0200060667032">
+                      <div></div>
+                      <div>
+                        <div>Pakkausmateriaalimaksu</div>
+                        <div>
+                          <div>0,60 €</div>
+                        </div>
+                      </div>
+                    </div>
+                    <div data-product-id="0200096900752">
+                      <div></div>
+                      <div>
+                        <div>Kotiinkuljetus</div>
+                        <div>
+                          <div>10,90 €</div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
+              </div>
             </div>
+          </div>
         </div>
+      </div>
     </div>
-</body>
-
+  </body>
 </html>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -18,8 +18,8 @@ Future<List<EANProduct>> html2EANProducts(String? filePath) async {
 /// Read EAN products from a [Document].
 void _html2EANProductsFromDocument(
     Document htmlDocument, List<EANProduct> eanProducts) {
-  var allProductsDiv = htmlDocument.body!.children[1].children[1].children[2]
-      .children[0].children[0].children[1].children[5];
+  var allProductsDiv = htmlDocument.body!.children[1].children[1].children[1]
+      .children[0].children[0].children[1].children[0].children[5];
   var childrenOfAllProductsDiv = allProductsDiv.children;
   for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {
     var product = childrenOfAllProductsDiv[i];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed & one extra div was added.