### PR TITLE
Fix S-kaupat HTML parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2
+
+- Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed.
+- Update S-kaupat example HTML file (to fix broken tests).
+
 ## 0.5.1
 
 - Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed & one extra div was added.

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -7,7 +7,6 @@
   <body>
     <div></div>
     <div>
-      <div></div>
       <div>
         <div></div>
         <div>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -18,7 +18,7 @@ Future<List<EANProduct>> html2EANProducts(String? filePath) async {
 /// Read EAN products from a [Document].
 void _html2EANProductsFromDocument(
     Document htmlDocument, List<EANProduct> eanProducts) {
-  var allProductsDiv = htmlDocument.body!.children[1].children[1].children[1]
+  var allProductsDiv = htmlDocument.body!.children[1].children[0].children[1]
       .children[0].children[0].children[1].children[0].children[5];
   var childrenOfAllProductsDiv = allProductsDiv.children;
   for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed.
- Update S-kaupat example HTML file (to fix broken tests).