### PR TITLE
Enhance the HTML parsing for S-kaupat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0
+
+- Parse S-kaupat HTML file more easily by using a query selector instead of a strict div hierarchy.
+  - This makes the parsing more precise, which reduces the previous problems when S-ryhmä changed its div hierarchy every week (see versions 0.3.0 – 0.5.2).
+
 ## 0.5.2
 
 - Fix an HTML parsing bug with handling an S-kaupat HTML file. One extra div was removed.

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -22,7 +22,7 @@
                   <div></div>
                   <div>
                     <div></div>
-                    <div data-product-id="6414894502399">
+                    <article data-product-id="6414894502399">
                       <div></div>
                       <div>
                         <div>Kotimaista ruusukaali 300 g Suomi</div>
@@ -33,8 +33,8 @@
                       <div>
                         <span><span>2</span><span>kpl</span></span>
                       </div>
-                    </div>
-                    <div data-product-id="6414894501231">
+                    </article>
+                    <article data-product-id="6414894501231">
                       <div></div>
                       <div>
                         <div>Kotimaista 1 kg suomalainen porkkana</div>
@@ -45,8 +45,8 @@
                       <div>
                         <span><span>1</span><span>kpl</span></span>
                       </div>
-                    </div>
-                    <div data-product-id="2000604700007">
+                    </article>
+                    <article data-product-id="2000604700007">
                       <div></div>
                       <div>
                         <div>Kurkku Suomi</div>
@@ -57,8 +57,8 @@
                       <div>
                         <span><span>3</span><span>kpl</span></span>
                       </div>
-                    </div>
-                    <div data-product-id="0200060667032">
+                    </article>
+                    <article data-product-id="0200060667032">
                       <div></div>
                       <div>
                         <div>Pakkausmateriaalimaksu</div>
@@ -66,8 +66,8 @@
                           <div>0,60 €</div>
                         </div>
                       </div>
-                    </div>
-                    <div data-product-id="0200096900752">
+                    </article>
+                    <article data-product-id="0200096900752">
                       <div></div>
                       <div>
                         <div>Kotiinkuljetus</div>
@@ -75,7 +75,7 @@
                           <div>10,90 €</div>
                         </div>
                       </div>
-                    </div>
+                    </article>
                   </div>
                 </div>
               </div>

--- a/lib/src/html_to_ean_products_s_kaupat.dart
+++ b/lib/src/html_to_ean_products_s_kaupat.dart
@@ -18,11 +18,9 @@ Future<List<EANProduct>> html2EANProducts(String? filePath) async {
 /// Read EAN products from a [Document].
 void _html2EANProductsFromDocument(
     Document htmlDocument, List<EANProduct> eanProducts) {
-  var allProductsDiv = htmlDocument.body!.children[1].children[0].children[1]
-      .children[0].children[0].children[1].children[0].children[5];
-  var childrenOfAllProductsDiv = allProductsDiv.children;
-  for (var i = 1; i < childrenOfAllProductsDiv.length; i++) {
-    var product = childrenOfAllProductsDiv[i];
+  var allProducts = htmlDocument.querySelectorAll('article');
+
+  for (var product in allProducts) {
     var totalPrice = double.parse(product
         .children[1].children[1].children[0].text
         .trim()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.5.2
+version: 0.6.0
 repository: https://github.com/areee/kassakuitti
 
 environment:


### PR DESCRIPTION
- Parse S-kaupat HTML file more easily by using a query selector instead of a strict div hierarchy.
  - This makes the parsing more precise, which reduces the previous problems when S-ryhmä changed its div hierarchy every week (see versions 0.3.0 – 0.5.2).