### PR TITLE
Add support for price per kilogram row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.8.0
+
+- Add support (or fix) for a weight & price per kilogram row.
+- Update some dependencies & Dart SDK version to the latest stable Flutter version (Dart 3.1.2).
+- Remove [_tuple_](https://pub.dev/packages/tuple) dependency & use [records](https://dart.dev/language/records).
+- Add an example row & update tests for the weight & price per kilogram row.
+
 ## 0.7.0
 
 - Update some dependencies & Dart SDK version to the latest stable Flutter version (Dart 3.0.0).

--- a/example/cash_receipt_example.txt
+++ b/example/cash_receipt_example.txt
@@ -3,8 +3,10 @@
  PORKKANAPUSSI                        1,35 
  KURKKU SUOMI                         4,50 
        3 KPL       1,50 €/KPL
+ Lohifilee B                         16,67 
+   0,882 KG       18,90 €/KG 
  PAKKAUSMATERIAALIT                   0,60 
  TOIMITUSMAKSU 10,90                 10,90 
                                  ----------
- YHTEENSÄ                            23,31 
- VERKKOMAKSU                         23,31 
+ YHTEENSÄ                            39,98 
+ VERKKOMAKSU                         39,98 

--- a/example/s-kaupat_example.html
+++ b/example/s-kaupat_example.html
@@ -58,6 +58,22 @@
                         <span><span>3</span><span>kpl</span></span>
                       </div>
                     </article>
+                    <article data-product-id="2396003800005">
+                      <div></div>
+                      <div>
+                        <div>Rainbow lohifilee noin 800g (600-1000g) vac</div>
+                        <div>
+                          <div>
+                            <div>
+                              <div>10,32 €</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div>
+                        <span><span>1</span><span>kpl</span></span>
+                      </div>
+                    </article>
                     <article data-product-id="0200060667032">
                       <div></div>
                       <div>

--- a/lib/src/kassakuitti_base.dart
+++ b/lib/src/kassakuitti_base.dart
@@ -7,7 +7,6 @@ import 'package:kassakuitti/src/models/receipt_product.dart';
 import 'package:kassakuitti/src/strings_to_receipt_products.dart';
 import 'package:kassakuitti/src/utils/selected_file_format_helper.dart';
 import 'package:kassakuitti/src/utils/selected_shop_helper.dart';
-import 'package:tuple/tuple.dart';
 
 /// Creates a new [Kassakuitti] instance.
 class Kassakuitti {
@@ -58,7 +57,7 @@ class Kassakuitti {
 
   /// Export recept products and EAN products into CSV or Excel file.
   /// Returns the path(s) of the exported file(s).
-  Future<Tuple2<String?, String>> export(
+  Future<(String?, String)> export(
       List<ReceiptProduct>? receiptProducts, List<EANProduct> eanProducts,
       {String? filePath}) async {
     if (selectedShop == SelectedShop.sKaupat) {
@@ -68,31 +67,31 @@ class Kassakuitti {
       }
       if (selectedFileFormat == SelectedFileFormat.csv) {
         // Export into CSV file
-        return Tuple2(
-            await exportReceiptProductsIntoCsv(receiptProducts, filePath),
-            await exportEANProductsIntoCsv(
-                eanProducts, selectedShop, filePath));
+        return (
+          await exportReceiptProductsIntoCsv(receiptProducts, filePath),
+          await exportEANProductsIntoCsv(eanProducts, selectedShop, filePath)
+        );
       } else {
         // Export into Excel file
-        return Tuple2(
-            await exportReceiptProductsIntoExcel(receiptProducts, filePath),
-            await exportEANProductsIntoExcel(
-                eanProducts, selectedShop, filePath));
+        return (
+          await exportReceiptProductsIntoExcel(receiptProducts, filePath),
+          await exportEANProductsIntoExcel(eanProducts, selectedShop, filePath)
+        );
       }
     } else {
       // Selected shop is K-ruoka
       if (selectedFileFormat == SelectedFileFormat.csv) {
         // Export into CSV file
-        return Tuple2(
-            null,
-            await exportEANProductsIntoCsv(
-                eanProducts, selectedShop, filePath));
+        return (
+          null,
+          await exportEANProductsIntoCsv(eanProducts, selectedShop, filePath)
+        );
       } else {
         // Export into Excel file
-        return Tuple2(
-            null,
-            await exportEANProductsIntoExcel(
-                eanProducts, selectedShop, filePath));
+        return (
+          null,
+          await exportEANProductsIntoExcel(eanProducts, selectedShop, filePath)
+        );
       }
     }
   }

--- a/lib/src/strings_to_receipt_products.dart
+++ b/lib/src/strings_to_receipt_products.dart
@@ -44,9 +44,12 @@ void _strings2ReceiptProductsFromList(
     } else if (row.contains('alennus') || row.contains('kampanja')) {
       // A discount or campaign row
       _handleDiscountOrCampaignRow(row, receiptProducts);
-    } else if (row.startsWith(RegExp(r'^\d+\s{1}kpl'))) {
+    } else if (row.startsWith(RegExp(r'^\d+\s{1}(KPL|kpl)'))) {
       // A quantity and price per unit row
       _handleQuantityAndPricePerUnitRow(row, receiptProducts);
+    } else if (row.startsWith(RegExp(r'^\d+,\d+\s{1}(KG|kg)'))) {
+      // A weight and price per kilogram row: skip it
+      continue;
     } else {
       // A "normal" row
       _handleNormalRow(row, receiptProducts);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,19 @@
 name: kassakuitti
 description: A Dart package for handling a cash receipt coming from S-kaupat or K-ruoka (two Finnish food online stores).
-version: 0.7.0
+version: 0.8.0
 repository: https://github.com/areee/kassakuitti
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.1.2
 
 dependencies:
   flutter_excel: ^1.0.1
-  html: ^0.15.3
+  html: ^0.15.4
   intl: ^0.18.1
   mime: ^1.0.4
   path: ^1.8.3
-  tuple: ^2.0.1
+  tuple: ^2.0.2
 
 dev_dependencies:
-  lints: ^2.1.0
-  test: ^1.24.2
+  lints: ^2.1.1
+  test: ^1.24.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   intl: ^0.18.1
   mime: ^1.0.4
   path: ^1.8.3
-  tuple: ^2.0.2
 
 dev_dependencies:
   lints: ^2.1.1

--- a/test/kassakuitti_test.dart
+++ b/test/kassakuitti_test.dart
@@ -526,7 +526,7 @@ void main() {
 
     test('Reading receiptProducts work', (() async {
       var receiptProducts = await kassakuitti.readReceiptProducts();
-      expect(receiptProducts.length, 5);
+      expect(receiptProducts.length, 6);
       expect(receiptProducts[0].name, 'ruusukaali');
       expect(receiptProducts[0].totalPrice, 5.96);
       expect(receiptProducts[0].quantity, 2);
@@ -539,19 +539,23 @@ void main() {
       expect(receiptProducts[2].totalPrice, 4.5);
       expect(receiptProducts[2].quantity, 3);
       expect(receiptProducts[2].pricePerUnit, 1.5);
-      expect(receiptProducts[3].name, 'pakkausmateriaalit');
-      expect(receiptProducts[3].totalPrice, 0.6);
+      expect(receiptProducts[3].name, 'lohifilee b');
+      expect(receiptProducts[3].totalPrice, 16.67);
       expect(receiptProducts[3].quantity, 1);
       expect(receiptProducts[3].pricePerUnit, null);
-      expect(receiptProducts[4].name, 'toimitusmaksu 10,90');
-      expect(receiptProducts[4].totalPrice, 10.9);
+      expect(receiptProducts[4].name, 'pakkausmateriaalit');
+      expect(receiptProducts[4].totalPrice, 0.6);
       expect(receiptProducts[4].quantity, 1);
       expect(receiptProducts[4].pricePerUnit, null);
+      expect(receiptProducts[5].name, 'toimitusmaksu 10,90');
+      expect(receiptProducts[5].totalPrice, 10.9);
+      expect(receiptProducts[5].quantity, 1);
+      expect(receiptProducts[5].pricePerUnit, null);
     }));
 
     test('Reading eanProducts work', (() async {
       var eanProducts = await kassakuitti.readEANProducts();
-      expect(eanProducts.length, 5);
+      expect(eanProducts.length, 6);
       expect(eanProducts[0].name, 'Kotimaista ruusukaali 300 g Suomi');
       expect(eanProducts[0].totalPrice, 5.96);
       expect(eanProducts[0].quantity, 2);
@@ -570,18 +574,25 @@ void main() {
       expect(eanProducts[2].pricePerUnit, 1.61);
       expect(eanProducts[2].eanCode, '2000604700007');
       expect(eanProducts[2].moreDetails, null);
-      expect(eanProducts[3].name, 'Pakkausmateriaalimaksu');
-      expect(eanProducts[3].totalPrice, 0.6);
+      expect(
+          eanProducts[3].name, 'Rainbow lohifilee noin 800g (600-1000g) vac');
+      expect(eanProducts[3].totalPrice, 10.32);
       expect(eanProducts[3].quantity, 1);
       expect(eanProducts[3].pricePerUnit, null);
-      expect(eanProducts[3].eanCode, '0200060667032');
+      expect(eanProducts[3].eanCode, '2396003800005');
       expect(eanProducts[3].moreDetails, null);
-      expect(eanProducts[4].name, 'Kotiinkuljetus');
-      expect(eanProducts[4].totalPrice, 10.9);
+      expect(eanProducts[4].name, 'Pakkausmateriaalimaksu');
+      expect(eanProducts[4].totalPrice, 0.6);
       expect(eanProducts[4].quantity, 1);
       expect(eanProducts[4].pricePerUnit, null);
-      expect(eanProducts[4].eanCode, '0200096900752');
+      expect(eanProducts[4].eanCode, '0200060667032');
       expect(eanProducts[4].moreDetails, null);
+      expect(eanProducts[5].name, 'Kotiinkuljetus');
+      expect(eanProducts[5].totalPrice, 10.9);
+      expect(eanProducts[5].quantity, 1);
+      expect(eanProducts[5].pricePerUnit, null);
+      expect(eanProducts[5].eanCode, '0200096900752');
+      expect(eanProducts[5].moreDetails, null);
     }));
   });
 

--- a/test/kassakuitti_test.dart
+++ b/test/kassakuitti_test.dart
@@ -165,10 +165,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item1!, isNotNull);
+      expect(filePaths.$1!, isNotNull);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts is not null', () async {
@@ -176,10 +176,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2, isNotNull);
+      expect(filePaths.$2, isNotNull);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported receiptProducts file exists', () async {
@@ -187,10 +187,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(await File(filePaths.item1!).exists(), true);
+      expect(await File(filePaths.$1!).exists(), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file exists', () async {
@@ -198,10 +198,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(await File(filePaths.item2).exists(), true);
+      expect(await File(filePaths.$2).exists(), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported receiptProducts file extension is CSV', () async {
@@ -209,10 +209,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item1!.endsWith('.csv'), true);
+      expect(filePaths.$1!.endsWith('.csv'), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported receiptProducts mime type is CSV', () async {
@@ -220,10 +220,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(lookupMimeType(filePaths.item1!), 'text/csv');
+      expect(lookupMimeType(filePaths.$1!), 'text/csv');
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file extension is CSV', () async {
@@ -231,10 +231,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2.endsWith('.csv'), true);
+      expect(filePaths.$2.endsWith('.csv'), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts mime type is CSV', () async {
@@ -242,10 +242,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(lookupMimeType(filePaths.item2), 'text/csv');
+      expect(lookupMimeType(filePaths.$2), 'text/csv');
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
   });
 
@@ -301,10 +301,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item1!, isNotNull);
+      expect(filePaths.$1!, isNotNull);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts is not null', () async {
@@ -312,10 +312,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2, isNotNull);
+      expect(filePaths.$2, isNotNull);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported receiptProducts file exists', () async {
@@ -323,10 +323,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(await File(filePaths.item1!).exists(), true);
+      expect(await File(filePaths.$1!).exists(), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file exists', () async {
@@ -334,10 +334,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(await File(filePaths.item2).exists(), true);
+      expect(await File(filePaths.$2).exists(), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported receiptProducts file extension is XLSX', () async {
@@ -345,10 +345,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item1!.endsWith('.xlsx'), true);
+      expect(filePaths.$1!.endsWith('.xlsx'), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported receiptProducts mime type is XLSX', () async {
@@ -356,11 +356,11 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(lookupMimeType(filePaths.item1!),
+      expect(lookupMimeType(filePaths.$1!),
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file extension is XLSX', () async {
@@ -368,10 +368,10 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2.endsWith('.xlsx'), true);
+      expect(filePaths.$2.endsWith('.xlsx'), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts mime type is XLSX', () async {
@@ -379,11 +379,11 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(receiptProducts, eanProducts,
           filePath: Directory.current.path);
-      expect(lookupMimeType(filePaths.item2),
+      expect(lookupMimeType(filePaths.$2),
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item1!).delete();
-      await File(filePaths.item2).delete();
+      await File(filePaths.$1!).delete();
+      await File(filePaths.$2).delete();
     });
   });
 
@@ -418,36 +418,36 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2, isNotNull);
+      expect(filePaths.$2, isNotNull);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file exists', () async {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(await File(filePaths.item2).exists(), true);
+      expect(await File(filePaths.$2).exists(), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file extension is CSV', () async {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2.endsWith('.csv'), true);
+      expect(filePaths.$2.endsWith('.csv'), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts mime type is CSV', () async {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(lookupMimeType(filePaths.item2), 'text/csv');
+      expect(lookupMimeType(filePaths.$2), 'text/csv');
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
   });
 
@@ -482,37 +482,37 @@ void main() {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2, isNotNull);
+      expect(filePaths.$2, isNotNull);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file exists', () async {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(await File(filePaths.item2).exists(), true);
+      expect(await File(filePaths.$2).exists(), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts file extension is XLSX', () async {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(filePaths.item2.endsWith('.xlsx'), true);
+      expect(filePaths.$2.endsWith('.xlsx'), true);
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
 
     test('Exported eanProducts mime type is XLSX', () async {
       final eanProducts = await kassakuitti.readEANProducts();
       final filePaths = await kassakuitti.export(null, eanProducts,
           filePath: Directory.current.path);
-      expect(lookupMimeType(filePaths.item2),
+      expect(lookupMimeType(filePaths.$2),
           'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
       // sleep(Duration(seconds: 2));
-      await File(filePaths.item2).delete();
+      await File(filePaths.$2).delete();
     });
   });
 


### PR DESCRIPTION
- Add support (or fix) for a weight & price per kilogram row.
- Update some dependencies & Dart SDK version to the latest stable Flutter version (Dart 3.1.2).
- Remove [_tuple_](https://pub.dev/packages/tuple) dependency & use [records](https://dart.dev/language/records).
- Add an example row & update tests for the weight & price per kilogram row.